### PR TITLE
Fix: API incorrect parameters

### DIFF
--- a/trello-backup.py
+++ b/trello-backup.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
         'key': '{0}'.format(api_key),
         'token': '{0}'.format(token),
         'filter': 'open',
-        'lists': 'open',
+        'fields': 'all',
     }
     # Parameters to get board contents
     board_payload = {
@@ -137,7 +137,6 @@ if __name__ == "__main__":
         'cards': 'all',
         'card_fields': 'all',
         'card_attachments': 'true',
-        'lists': 'all',
         'list_fields': 'all',
         'members': 'all',
         'member_fields': 'all',


### PR DESCRIPTION
Trello seems to be giving a 401 now if you incorrectly call their api which it seems we were doing for eternity.

https://developers.trello.com/v1.0/reference#organizationsidboards says the only parameters needed are "filter" and "fields". If you added "lists" it would result in a 401.

Previous:
 ```
DEBUG - Trying to find Orgs for [u'thingy']
INFO - Finding all Organizations.
DEBUG - Org Added: thingy_ID
DEBUG - Organization_ids: [u'thingy_ID']
ERROR - Unable to access your boards. Check your key and token.
# Response back (added in testing, not added in PR):
DEBUG - Board Response: <Response [401]>
```

Now: 
```
DEBUG - Trying to find Orgs for [u'thingy']
INFO - Finding all Organizations.
DEBUG - Org Added: thingy_ID
DEBUG - Organization_ids: [u'thingy_ID']
INFO - Backing up boards:
INFO -  Our First Board (first_board_ID)
......etc
```

----

Also removed duplicate "lists" parameter when querying the boards.